### PR TITLE
Fixed issue where user can insert sb X and be recognized as sb X.1

### DIFF
--- a/ShellBuddyCLI/main.swift
+++ b/ShellBuddyCLI/main.swift
@@ -1,4 +1,3 @@
-//
 //  main.swift
 //  ShellBuddyCLI
 //
@@ -82,7 +81,13 @@ func sbCLIMain() {
     }
     
     // Get the argument
-    let argument = arguments[1]
+    var argument = arguments[1]
+    
+    // Check if the argument can be cast to an integer
+    if let intArg = Int(argument) {
+        // Convert integer argument to float with ".1" suffix
+        argument = "\(intArg).1"
+    }
     
     // Check if the argument can be cast to a float
     if let _ = Float(argument) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated logic in handling command-line arguments to convert integer arguments to float by adding a ".1" suffix.
	- Changed declaration of an entity to improve functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->