### PR TITLE
Fix positionAndSizeWindow for monitors with different resolutions

### DIFF
--- a/ShellMate/WindowPositionManager.swift
+++ b/ShellMate/WindowPositionManager.swift
@@ -15,21 +15,21 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
     var focusedTerminalWindowID: CGWindowID? = nil
     var previousFocusedWindowID: CGWindowID? = nil
 
-
+    
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         print("Application did finish launching.")
         initializeFocusedWindowID() // Required in case app launches with terminal already open
-
+        
         NotificationCenter.default.addObserver(self, selector: #selector(handleUpdatedAppPositionAfterWindowAttachmentChange(_:)), name: .updatedAppPositionAfterWindowAttachmentChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleReinitializeTerminalWindowID), name: .reinitializeTerminalWindowID, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateAppWindowPositionAndSize), name: .manualUpdateAppWindowPositionAndSize, object: nil)
     }
-
+    
     func initializeFocusedWindowID() {
         guard let windowData = getTerminalWindowPositionAndSize() else {
             return
         }
-
+        
         if let windowID = windowData.windowID {
             print("DEBUG: terminal window initialized")
             NotificationCenter.default.post(name: .terminalWindowIdDidChange, object: self, userInfo: [
@@ -37,14 +37,14 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
                 "terminalWindow": windowData.focusedWindow!
             ])
         }
-
+        
         positionAndSizeWindow(terminalPosition: windowData.position, terminalSize: windowData.size, shouldAnimate: true)
     }
-
+    
     @objc func handleReinitializeTerminalWindowID(_ notification: Notification) {
         initializeFocusedWindowID()
     }
-
+    
     @objc func handleTerminalLaunch(_ notification: Notification) {
         guard let userInfo = notification.userInfo,
               let launchedApp = userInfo[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
@@ -54,7 +54,7 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
         setupTerminalObserver()
         initializeFocusedWindowID() // Required in case app launches with terminal not open yet
     }
-
+    
     @objc func handleTerminalTermination(_ notification: Notification) {
         guard let userInfo = notification.userInfo,
               let terminatedApp = userInfo[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
@@ -65,28 +65,28 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
         miniaturizeAppWindow()
         isTerminalFocused = false  // Reset the focused state when Terminal is terminated
     }
-
+    
     @objc func handleUpdatedAppPositionAfterWindowAttachmentChange(_ notification: Notification) {
         guard let windowData = getTerminalWindowPositionAndSize() else {
             return
         }
         positionAndSizeWindow(terminalPosition: windowData.position, terminalSize: windowData.size, shouldAnimate: true)
     }
-
+    
     func initializeObserverForRunningTerminal() {
         if NSWorkspace.shared.runningApplications.contains(where: { $0.bundleIdentifier == "com.apple.Terminal" }) {
             setupTerminalObserver()
         }
     }
-
+    
     func setupTerminalObserver() {
         print("Setting up observer for Terminal.")
-
+        
         guard let terminalApp = NSWorkspace.shared.runningApplications.first(where: { $0.bundleIdentifier == "com.apple.Terminal" }) else {
             print("Terminal application is not running.")
             return
         }
-
+        
         var observer: AXObserver?
         let pid = terminalApp.processIdentifier
         let callback: AXObserverCallback = { (observer, element, notification, refcon) in
@@ -94,31 +94,31 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
             let delegate = Unmanaged<WindowPositionManager>.fromOpaque(refcon!).takeUnretainedValue()
             delegate.updateAppWindowPositionAndSize(notification: notification as CFString) // Pass the notification
         }
-
+        
         let result = AXObserverCreate(pid_t(pid), callback, &observer)
-
+        
         if result != .success {
             print("Failed to create AXObserver for Terminal. Error: \(result.rawValue)")
             return
         }
-
+        
         self.terminalObserver = observer
-
+        
         guard let observer = observer else {
             print("Failed to create AXObserver.")
             return
         }
-
+        
         let terminalElement = AXUIElementCreateApplication(pid_t(pid))
         let runLoopSource = AXObserverGetRunLoopSource(observer)
         CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .defaultMode)
         print("Observer added to run loop for Terminal.")
-
+        
         let refcon = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
         addNotifications(to: observer, element: terminalElement, refcon: refcon)
         updateAppWindowPositionAndSize(notification: kAXFocusedWindowChangedNotification as CFString)
     }
-
+    
     func removeTerminalObserver() {
         guard let observer = terminalObserver else { return }
         let runLoopSource = AXObserverGetRunLoopSource(observer)
@@ -126,7 +126,7 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
         terminalObserver = nil
         print("Observer removed for Terminal.")
     }
-
+    
     func addNotifications(to observer: AXObserver, element: AXUIElement, refcon: UnsafeMutableRawPointer) {
         let notifications = [
             kAXFocusedWindowChangedNotification as CFString,
@@ -140,7 +140,7 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
             kAXResizedNotification as CFString,
             kAXFocusedUIElementChangedNotification as CFString  // To detect tab changes from the same terminal.
         ]
-
+        
         for notification in notifications {
             let result = AXObserverAddNotification(observer, element, notification, refcon)
             if result != .success {
@@ -148,7 +148,7 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
             }
         }
     }
-
+    
     func getTerminalWindowPositionAndSize() -> (position: CGPoint, size: CGSize, windowID: CGWindowID?, focusedWindow: AXUIElement?)? {
         guard let terminalApp = NSWorkspace.shared.runningApplications.first(where: { $0.bundleIdentifier == "com.apple.Terminal" }) else {
             print("Terminal application is not running.")
@@ -166,7 +166,7 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
             print("Unable to retrieve window title")
             return nil
         }
-
+        
         let position = getWindowPosition(for: focusedWindow)
         let size = getWindowSize(for: focusedWindow)
 
@@ -174,7 +174,7 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
         return (position, size, currentWindowID, focusedWindow)
     }
 
-
+    
     @objc func updateAppWindowPositionAndSize(notification: CFString = kAXFocusedWindowChangedNotification as CFString) {
         DispatchQueue.main.async {  // Ensure all operations within this block are executed on the main thread
             print("Updating app window position and size.")
@@ -214,7 +214,7 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
                     self.miniaturizeAppWindow()
                     return
                 }
-
+                
                 // Get the window's title
                 guard let title = self.getWindowTitle(for: focusedWindow) else {
                     // This check is necessary to avoid attaching ShellMate to non-terminal windows
@@ -231,7 +231,7 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
                 let position = self.getWindowPosition(for: focusedWindow)
                 let size = self.getWindowSize(for: focusedWindow)
                 self.focusedTerminalWindowID = self.findWindowID(for: position, size: size, pid: terminalApp.processIdentifier)
-
+                
                 var shouldBringToFront = false
 
                 if !wasTerminalFocused && self.isTerminalFocused {
@@ -257,10 +257,10 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
                 let shouldAnimate = (notification == kAXWindowMovedNotification as CFString)
                 // Call the function with the updated parameters
                 positionAndSizeWindow(terminalPosition: position, terminalSize: size, shouldAnimate: shouldAnimate)
-
+                
             } else {
                 print("Failed to get windows for Terminal.")
-
+                
                 // Check if the app has accessibility access
                 if !AccessibilityChecker.isAppTrusted() {
                     showPermissionsView()
@@ -271,12 +271,12 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
     }
 
 
-
+    
     func isTerminalAppFocused(_ terminalApp: NSRunningApplication) -> Bool {
         let systemWideElement = AXUIElementCreateSystemWide()
         var focusedApp: CFTypeRef?
         let focusedAppResult = AXUIElementCopyAttributeValue(systemWideElement, kAXFocusedApplicationAttribute as CFString, &focusedApp)
-
+        
         if focusedAppResult == .success, let focusedAppElement = focusedApp {
             var appPID: pid_t = 0
             AXUIElementGetPid(focusedAppElement as! AXUIElement, &appPID)
@@ -284,21 +284,21 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
         }
         return false
     }
-
+    
     func getFocusedWindow(for terminalApp: NSRunningApplication) -> AXUIElement? {
         let terminalElement = AXUIElementCreateApplication(terminalApp.processIdentifier)
         var focusedWindow: CFTypeRef?
         let focusedWindowResult = AXUIElementCopyAttributeValue(terminalElement, kAXFocusedWindowAttribute as CFString, &focusedWindow)
         return focusedWindowResult == .success ? (focusedWindow as! AXUIElement) : nil
     }
-
+    
     func bringAppWindowToFrontWithoutFocus() {
         DispatchQueue.main.async {
             guard let window = NSApplication.shared.windows.first else {
                 print("Failed to find the application window.")
                 return
             }
-
+            
             window.level = .floating
             window.orderFrontRegardless()  // Bring the window to the front without stealing focus
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
@@ -306,36 +306,36 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
             }
         }
     }
-
+    
     func miniaturizeAppWindow() {
         guard let window = NSApplication.shared.windows.first else {
             print("Failed to find the application window.")
             return
         }
-
+        
         // Retrieve the saved window attachment position from UserDefaults
         let savedPosition = UserDefaults.standard.string(forKey: "windowAttachmentPosition") ?? WindowAttachmentPosition.float.rawValue
         guard let attachmentPosition = WindowAttachmentPosition(rawValue: savedPosition) else {
             print("Invalid attachment position saved in UserDefaults.")
             return
         }
-
+        
         // Check the current state of the attachment position. If it is float, just return and don't miniaturize
         if attachmentPosition == .float {
             print("Attachment position is 'float'. Will not miniaturize")
             return
         }
-
+        
         // Miniaturize the window if it's not in float state
         window.miniaturize(nil)
     }
-
+    
     func getWindowTitle(for window: AXUIElement) -> String? {
         var windowTitle: CFTypeRef?
         let result = AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &windowTitle)
         return result == .success ? windowTitle as? String : nil
     }
-
+    
     func getWindowPosition(for window: AXUIElement) -> CGPoint {
         var position: CFTypeRef?
         let result = AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &position)
@@ -345,7 +345,7 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
         }
         return point
     }
-
+    
     func getWindowSize(for window: AXUIElement) -> CGSize {
         var size: CFTypeRef?
         let result = AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &size)
@@ -355,7 +355,7 @@ class WindowPositionManager: NSObject, NSApplicationDelegate {
         }
         return sizeValue
     }
-
+    
     func findWindowID(for position: CGPoint, size: CGSize, pid: pid_t) -> CGWindowID? {
         let windowListOption = CGWindowListOption(arrayLiteral: .optionOnScreenOnly, .excludeDesktopElements)
         guard let cgWindowListInfo = CGWindowListCopyWindowInfo(windowListOption, kCGNullWindowID) as? [[String: Any]] else {
@@ -384,13 +384,13 @@ func positionAndSizeWindow(terminalPosition: CGPoint, terminalSize: CGSize, shou
             print("Failed to find the application window or screen.")
             return
         }
-
+        
         // terminalPosition is calculated relative to the height of the primaryScreen
         guard let primaryScreen = NSScreen.screens.first(where: { $0.frame.origin.y == 0 }) else {
             print("Failed to find the primary screen.")
             return
         }
-
+        
         // Get the saved window attachment position from UserDefaults
         let savedPosition = UserDefaults.standard.string(forKey: "windowAttachmentPosition") ?? "right"
         guard let attachmentPosition = WindowAttachmentPosition(rawValue: savedPosition) else {
@@ -398,12 +398,12 @@ func positionAndSizeWindow(terminalPosition: CGPoint, terminalSize: CGSize, shou
             return
         }
         print("Saved position: \(savedPosition)")
-
+        
         // Calculate the new y position
         // terminalPosition is relative to primaryScreen, not NSScreen.main
         let screenHeight = primaryScreen.frame.height
         let newYPosition = screenHeight - terminalPosition.y - terminalSize.height
-
+        
         // Calculate the new x position based on the attachmentPosition enum
         let newXPosition: CGFloat
         switch attachmentPosition {
@@ -414,11 +414,11 @@ func positionAndSizeWindow(terminalPosition: CGPoint, terminalSize: CGSize, shou
         case .float:
             return
         }
-
+        
         // Calculate the new position
         let newPosition = CGPoint(x: newXPosition, y: newYPosition)
         let newSize = CGSize(width: window.frame.width, height: terminalSize.height)
-
+        
         if shouldAnimate {
             // Animate the window position change
             NSAnimationContext.runAnimationGroup({ context in


### PR DESCRIPTION
Fixes #119 

I initially had a bunch of whitespace changes, which makes me think we should probably run the codebase through [swift-format](https://github.com/swiftlang/swift-format) at some point for consistency. This could reduce noise in the PRs. I don't have any preferences on the configuration -- let me know if you do!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved accuracy of application window positioning by refining screen dimension logic.
  
- **Bug Fixes**
	- Enhanced error handling for identifying the primary screen, providing clearer feedback when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->